### PR TITLE
Add call to os.close.

### DIFF
--- a/doc/print.py
+++ b/doc/print.py
@@ -46,6 +46,7 @@ def main():
       fdpath = '/proc/self/fd/{:d}'.format(event.fd)
       full_path = os.readlink(fdpath)
       print(full_path)
+      os.close(event.fd)
     assert not buf
 
 if __name__ == '__main__':


### PR DESCRIPTION
Unless event.fd is closed, the example print.py script exhausts the available file descriptors.  