### PR TITLE
Add null termination for PyMethodDef.

### DIFF
--- a/fanotify.c
+++ b/fanotify.c
@@ -388,6 +388,7 @@ static PyMethodDef fanotify_methods[] = {
     fanotify_EventOk_doc},
   {"Response", (PyCFunction)fanotify_Response, METH_VARARGS | METH_KEYWORDS,
     fanotify_Response_doc},
+  {NULL}
 };
 
 /* Module definition struct for python3. */


### PR DESCRIPTION
Adding a null termination for PyMethodDef fixed a crash upon module import for an aarch64 system.  